### PR TITLE
Add gapless playback (WIP)

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -335,6 +335,8 @@
             fileSize: track.fileSize,
             url: track.url,
           });
+          player.enqueue(TRACKS[1]);
+          player.enqueue(TRACKS[2]);
         }
 
         STATE.playbackState = 'PLAYING';

--- a/src/ClipState.js
+++ b/src/ClipState.js
@@ -48,6 +48,10 @@ export default class ClipState extends EventEmitter {
     );
   }
 
+  isExhausted() {
+    return this._chunkIndex === this._lastAllowedChunkIndex - 1;
+  }
+
   get fileSize() {
     return this._fileSize;
   }

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -1,0 +1,21 @@
+export default class Queue {
+  constructor() {
+    this.queue = [];
+  }
+
+  push(clip) {
+    this.queue.push(clip);
+  }
+
+  currentClip() {
+    if (this.queue.length === 0) return null;
+
+    const currentClip = this.queue[0];
+    if (currentClip._clipState.isExhausted()) {
+      this.queue = this.queue.slice(1);
+      return this.currentClip();
+    }
+
+    return currentClip;
+  }
+}

--- a/src/interface/AudioContext.js
+++ b/src/interface/AudioContext.js
@@ -32,15 +32,15 @@ function initialize({ volume = 1.0 }) {
   currentClip = null;
 }
 
-function play(clip) {
+function play(queue) {
   gain = context.createGain();
   gain.connect(context.destination);
   context.resume();
 
+  const clip = queue.currentClip();
   setVolume(clip.volume);
-
   currentClip = clip;
-  _play(clip);
+  _play(queue);
 
   return Promise.resolve();
 }
@@ -83,7 +83,9 @@ function getPlaybackState() {
   return PlaybackState.Playing;
 }
 
-function _play(clip) {
+function _play(queue) {
+  let clip = queue.currentClip();
+
   clip._playbackProgress = 0;
   clip._scheduledEndTime = null;
 
@@ -168,6 +170,8 @@ function _play(clip) {
 
     const advance = () => {
       if (!playing) return;
+
+      clip = queue.currentClip();
 
       if (!_playingSilence && clip._lastPlayedChunk === clip._clipState.chunkIndex) {
         clip._clipState.chunkIndex += 1;

--- a/src/interface/MediaSource.js
+++ b/src/interface/MediaSource.js
@@ -32,11 +32,11 @@ function initialize({ volume = 1.0 }) {
   setVolume(volume);
 }
 
-function play(clip) {
+function play(queue) {
   source = new MediaSource();
   source.addEventListener('sourceopen', function () {
     sourceBuffer = this.addSourceBuffer('audio/mpeg');
-    _play(clip);
+    _play(queue);
   });
 
   audioElement.src = URL.createObjectURL(source);
@@ -44,8 +44,10 @@ function play(clip) {
   return audioElement.play().catch(suppressAbortError);
 }
 
-function _play(clip) {
-  if (clip._clipState.chunksBufferingFinished) {
+function _play(queue) {
+  const clip = queue.currentClip();
+
+  if (!clip) {
     debug('MediaSourceEngine endOfStream()');
     source.endOfStream();
     return;
@@ -84,7 +86,7 @@ function _play(clip) {
   }
 
   const timeout = isChunkReady ? Math.min(500, chunk.duration * 1000) : 100;
-  sourceTimeout = setTimeout(() => _play(clip), timeout);
+  sourceTimeout = setTimeout(() => _play(queue), timeout);
 }
 
 function resume() {


### PR DESCRIPTION
This PR implements gapless playback. Tracks can now be "queued", causing them to be automatically preloaded and gaplessly transitioned to when the currently playing song ends. It will be possible to manage the queue through the Player's API, although the extent of this control will be limited at first.

- [ ] Update public API to support queue management
- [ ] Rework `Clip` events (some of these belong in the MediaSource/AudioContext interfaces)
- [ ] Update example code (no longer needs to manage its own queue)
- [ ] Extended play tests (check for memory leaks, state mgmt issues)
- [ ] Mobile device tests